### PR TITLE
Add support for higher order proxy

### DIFF
--- a/src/AnyServiceProvider.php
+++ b/src/AnyServiceProvider.php
@@ -19,5 +19,7 @@ final class AnyServiceProvider extends ServiceProvider
 
         Collection::macro('any', Any::invokable());
         LazyCollection::macro('any', Any::invokable());
+
+        Collection::proxy('any');
     }
 }

--- a/tests/unit/higher-order-proxy.php
+++ b/tests/unit/higher-order-proxy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+use NunoMaduro\LaravelAny\AnyServiceProvider;
+
+$app = new Application;
+$app->register(AnyServiceProvider::class);
+
+it('can proxy method calls to collection item', function (): void {
+    $collection = collect([new ExampleProxyTarget]);
+
+    assertFalse($collection->any->false());
+    assertTrue($collection->any->true());
+});
+
+class ExampleProxyTarget
+{
+    public function false(): bool
+    {
+        return false;
+    }
+
+    public function true(): bool
+    {
+        return true;
+    }
+}

--- a/tests/unit/higher-order-proxy.php
+++ b/tests/unit/higher-order-proxy.php
@@ -15,8 +15,18 @@ it('can proxy method calls to collection item', function (): void {
     assertTrue($collection->any->true());
 });
 
+it('can proxy the call and evaluate property checks', function (): void {
+    $collection = collect([new ExampleProxyTarget]);
+
+    assertFalse($collection->any->falseProperty);
+    assertTrue($collection->any->trueProperty);
+});
+
 class ExampleProxyTarget
 {
+    public $trueProperty = true;
+    public $falseProperty = false;
+
     public function false(): bool
     {
         return false;


### PR DESCRIPTION
This PR adds support for a higher order proxy using the `any()` method.

There is a test supplied too, although it is quite a simple test that just checks that the methods are being called correctly when proxying.

Example usage:

```php
class User extends Model
{
    protected $fillable = ['has_paid_plan'];
}

User::all()->any->has_paid_plan;
```

It will also work for method calls on the class / item being proxied.

```php
class User extends Model
{
    public function hasPaidPlan()
    {
        return $this->has_paid_plan;
    }
}

User::all()->any->hasPaidPlan();
```